### PR TITLE
fix cluster resize

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -217,8 +217,7 @@ resource "aws_msk_cluster" "default" {
 
   lifecycle {
     ignore_changes = [
-      # Ignore changes to ebs_volume_size in favor of autoscaling policy
-      broker_node_group_info[0].storage_info[0].ebs_storage_info[0].volume_size,
+      broker_node_group_info[0].storage_info[0].ebs_storage_info[0].provisioned_throughput
     ]
   }
 


### PR DESCRIPTION
## what

Remove ignore changes for EBS volume size, it breaks resizes.



## why

Impossible to (Terraform) resize a cluster with the current code and impossible to apply Terraform after a resize in the console, even after an import of the cluster.

I know there is ongoing work in https://github.com/cloudposse/terraform-aws-msk-apache-kafka-cluster/pull/101 that might also include a fix for this, but it looks like it will take more time to get that done. This is a basic fix.

## references

AWS provider issue: https://github.com/hashicorp/terraform-provider-aws/issues/26031
Cloudposse module issue: https://github.com/cloudposse/terraform-aws-msk-apache-kafka-cluster/issues/99
Upstream PR with this fix: https://github.com/cloudposse/terraform-aws-msk-apache-kafka-cluster/pull/103

Internal Asana: https://app.asana.com/0/1206364880660348/1206676435555704
